### PR TITLE
Fixed rosco url in orca config.

### DIFF
--- a/config/orca.yml
+++ b/config/orca.yml
@@ -1,6 +1,6 @@
 bakery:
   allowMissingPackageInstallation: true
-  baseUrl: http://spinnaker-rosco:8087
+  baseUrl: http://rosco-alias:8087
   extractBuildDetails: true
   propagateCloudProviderType: true
 default:


### PR DESCRIPTION
Attempting to Bake would return Exception: spinnaker-rosco: unknown error. Orca had invalid url for rosco set up.
