### PR TITLE
The baby steps of success - A spinnaker story. 

### DIFF
--- a/clone.py
+++ b/clone.py
@@ -26,5 +26,5 @@ for service in services:
 print "building deck"
 cmd("git clone https://github.com/spinnaker/deck.git services/deck")
 deckPath = os.path.abspath("services/deck")
-cmd('docker run --rm -v ' + deckPath + ':/build -e AUTH_ENABLED=false -e API_HOST=/gate -e BAKERY_DETAIL_URL=/bakery quay.io/spinnaker/deck bash -c "cd /build; npm install; npm run build"')
+cmd('docker run --rm -v ' + deckPath + ':/build -e AUTH_ENABLED=false -e API_HOST=/gate -e BAKERY_DETAIL_URL=/bakery quay.io/spinnaker/deck bash -c "ulimit -n 2048; cd /build; npm install; npm run build"')
 print "deck built inside services/deck/build/webpack"

--- a/clone.py
+++ b/clone.py
@@ -15,8 +15,8 @@ def handleRemoveReadonly(func, path, exc): # Delete readonly files (windows)
 
 if os.path.exists("services"):
     shutil.rmtree("services", ignore_errors=False, onerror=handleRemoveReadonly)
-else:
-    cmd("mkdir services")
+
+cmd("mkdir services")
 
 for service in services:
     cmd("git clone https://github.com/spinnaker/" + service + ".git services/" + service)


### PR DESCRIPTION
Successfully ran the clone.py after upgrading to docker beta for windows. (symlink issue with docker stable breaks npm) 

**Changes**:
- Services directory does always need to be created.
- Bumped up the ulimit (ran into some issues with too many npm files).

**Known issue**: On windows deleting of the services directory will fail because some parts of the path are too long for windows to handle. 

**Possible solutions**: 
- Never delete services if they have already been cloned. Git pull instead.
- Try to capture the error, use win32api to generate a short path and delete using the short path. 
